### PR TITLE
fix: repair jq merge to unblock updates

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Re-Merge
         id: remerge
         run: |
-          jq -n '[inputs|add]' versions/go*.json | jq -S . > all-versions.json
+          jq -n '[inputs]' versions/go*.json | jq -S . > all-versions.json
           git add all-versions.json
       - name: commit
         id: commit


### PR DESCRIPTION
This PR alters the JQ merge:
```
jq -n '[inputs|add]' versions/go*.json | jq -S . > all-versions.json
jq: error (at versions/go1.21.11.json:420): string ("go1.21.11") and boolean (true) cannot be added
```

Without the `add`, it seems to work to accumulate an `all-versions.json` file